### PR TITLE
fix https://github.com/toadchild/40kdice/issues/23

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -69,6 +69,19 @@ function success_chance(stat, crit, modifier) {
     return ret;
 }
 
+// Rerolls
+function do_rerolls(prob, reroll_type) {
+    if (reroll_type == 'fail') {
+        prob = reroll(prob);
+    } else if (reroll_type == '1') {
+        prob = reroll_1(prob);
+    } else if (reroll_type == 'noncrit') {
+        prob = reroll_noncrit(prob);
+    }
+
+    return prob;
+}
+
 // Reroll 1s
 // Returns new success probability struct with updated values.
 function reroll_1(prob){
@@ -334,15 +347,7 @@ function do_hits(hit_stat, hit_mod, hit_reroll, attacks, hit_abilities, damage_p
 
 function calc_wound_prob(wound_stat, wound_crit, wound_mod, wound_reroll, hit_abilities, hit_prob) {
     var wound_prob = success_chance(wound_stat, wound_crit, wound_mod);
-
-    // Rerolls
-    if (wound_reroll == 'fail') {
-        wound_prob = reroll(wound_prob);
-    } else if (wound_reroll == '1') {
-        wound_prob = reroll_1(wound_prob);
-    } else if (wound_reroll == 'noncrit') {
-        wound_prob = reroll_noncrit(wound_prob);
-    }
+    wound_prob = do_rerolls(wound_prob, wound_reroll);
 
     // Auto-wound on roll of 6+
     // Only apply normal wound probability to lesser hits
@@ -673,14 +678,7 @@ function roll_40k() {
     }
     var hit_prob = success_chance(hit_stat, hit_crit, hit_mod);
 
-    // Rerolls
-    if (hit_reroll == 'fail') {
-        hit_prob = reroll(hit_prob);
-    } else if (hit_reroll == '1') {
-        hit_prob = reroll_1(hit_prob);
-    } else if (hit_reroll == 'noncrit') {
-        hit_prob = reroll_noncrit(hit_prob);
-    }
+    hit_prob = do_rerolls(hit_prob, hit_reroll);
 
     var hit_abilities = {
         '+hit': hit_sus,
@@ -764,6 +762,9 @@ function roll_aos() {
         hit_mod = 1;
     }
     var hit_prob = success_chance(hit_stat, 6, hit_mod);
+
+    hit_prob = do_rerolls(hit_prob, hit_reroll);
+
     var hit_abilities = {};
     if (hit_of_6 == '1') {
         hit_abilities['+hit'] = '1';

--- a/dice.js
+++ b/dice.js
@@ -278,13 +278,10 @@ function do_hits(hit_stat, hit_mod, hit_reroll, attacks, hit_abilities, damage_p
     // Rerolls
     if (hit_reroll == 'fail') {
         hit_title += ', reroll misses';
-        hit_prob = reroll(hit_prob);
     } else if (hit_reroll == '1') {
         hit_title += ', reroll 1s';
-        hit_prob = reroll_1(hit_prob);
     } else if (hit_reroll == 'noncrit') {
         hit_title += ', reroll non-crits';
-        hit_prob = reroll_noncrit(hit_prob);
     }
 
     log_prob_array('Attacks', attacks);
@@ -675,6 +672,16 @@ function roll_40k() {
         hit_mod = 1;
     }
     var hit_prob = success_chance(hit_stat, hit_crit, hit_mod);
+
+    // Rerolls
+    if (hit_reroll == 'fail') {
+        hit_prob = reroll(hit_prob);
+    } else if (hit_reroll == '1') {
+        hit_prob = reroll_1(hit_prob);
+    } else if (hit_reroll == 'noncrit') {
+        hit_prob = reroll_noncrit(hit_prob);
+    }
+
     var hit_abilities = {
         '+hit': hit_sus,
         'autowound': hit_leth,

--- a/test.js
+++ b/test.js
@@ -493,6 +493,8 @@ function qunit_test() {
         var damage_prob = parse_dice_prob_array('1').normal;
         var hit_prob = success_chance(hit_stat, 6, hit_mod);
 
+        hit_prob = do_rerolls(hit_prob, hit_reroll);
+
         var hits = do_hits(hit_stat, hit_mod, hit_reroll, attacks, hit_abilities, damage_prob, hit_prob);
 
         var expected = {
@@ -522,6 +524,7 @@ function qunit_test() {
         var attacks = parse_dice_prob_array(hit_dice);
         var damage_prob = parse_dice_prob_array('1').normal;
         var hit_prob = success_chance(hit_stat, 6, hit_mod);
+        hit_prob = do_rerolls(hit_prob, hit_reroll);
 
         var hits = do_hits(hit_stat, hit_mod, hit_reroll, attacks, hit_abilities, damage_prob, hit_prob);
 
@@ -552,6 +555,7 @@ function qunit_test() {
         var attacks = parse_dice_prob_array(hit_dice);
         var damage_prob = parse_dice_prob_array('1').normal;
         var hit_prob = success_chance(hit_stat, 6, hit_mod);
+        hit_prob = do_rerolls(hit_prob, hit_reroll);
 
         var hits = do_hits(hit_stat, hit_mod, hit_reroll, attacks, hit_abilities, damage_prob, hit_prob);
 
@@ -891,6 +895,46 @@ function qunit_test() {
                 0.8148148148148149,
                 0.18518518518518517
             ]
+        };
+        assert.deepEqual(wounds, expected, "wounds");
+    });
+
+    QUnit.test('one hit roll with reroll non-crit and autowound on 6, wound roll', function(assert) {
+        var hit_stat = 3;
+        var hit_mod = 0;
+        var hit_dice = '1';
+        var hit_reroll = 'noncrit';
+        var hit_abilities = {
+            'autowound': true
+        };
+
+        var attacks = parse_dice_prob_array(hit_dice);
+        var damage_prob = parse_dice_prob_array('1').normal;
+        var hit_prob = success_chance(hit_stat, 6, hit_mod);
+        hit_prob = do_rerolls(hit_prob, hit_reroll);
+        var hits = do_hits(hit_stat, hit_mod, hit_reroll, attacks, hit_abilities, damage_prob, hit_prob);
+
+        var wound_stat = 5;
+        var wound_mod = 0;
+        var wound_crit = 6;
+        var wound_reroll = '';
+        var wound_abilities = {};
+        var wound_prob = calc_wound_prob(wound_stat, wound_crit, wound_mod, wound_reroll, hit_abilities, hit_prob);
+        var wounds = do_wounds(wound_stat, wound_mod, wound_reroll, wound_prob, hits, wound_abilities, damage_prob);
+
+        var expected = 	{
+          "mortal": [
+            [
+              0.5555555555555556
+            ],
+            [
+              0.4444444444444445
+            ]
+          ],
+          "normal": [
+            0.5555555555555556,
+            0.4444444444444445
+          ]
         };
         assert.deepEqual(wounds, expected, "wounds");
     });


### PR DESCRIPTION
1) hit_prob rerolls calculate inside do_hits()
2) hit_prob uses inside calc_wound_prob() without rerolls affected